### PR TITLE
Add a description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-debounced-properties",
   "version": "0.0.1",
+  "description": "Simple way to define debounced properties",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Currently if no description is present, npm uses the first paragraph, and in this case it's truncated and you have partial instructions on npm. Feel free to suggest alternative description.
