### PR TITLE
Support @debounced ES7 decorator syntax

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,7 +2,11 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+var app = new EmberAddon({
+  babel: {
+    optional: ['es7.decorators']
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ npm install ember-debounced-properties --save-dev
     ```
 
 3. `debouncedValue` will follow `value` after a short delay. You can set the delay with `valueDelay`.
+
     ```hbs
     {{input value=value}} <- after you done typing it will appear 1.5 seconds later below
     {{my-component value=value valueDelay=1500}}
@@ -65,6 +66,44 @@ export default Ember.Component.extend(DebouncedPropertiesMixin, {
 ```handlebars
 {{gravatar-image email='hello@example.com'}}
 ```
+
+## Experimental ES7 decorator syntax
+
+Inspired by [@rwjblue](https://github.com/rwjblue)'s awesome [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators), it is possible to use the ES7 decorator syntax to define debounced properties without using the mixin. All you have to do is just put a decorator over the property you want to have a debounced version. It can be a regular or a computed property, both will work.
+
+```js
+import Ember from 'ember';
+import debounced from 'ember-debounced-properties/decorator';
+
+port default Ember.Component.extend({
+  firstName: 'John',
+  lastName: 'Doe',
+
+  @debounced(2000)
+  fullName: Ember.computed('firstName', 'lastName', function() {
+    return `${firstName} ${lastName}`;
+  })
+});
+```
+
+The result is the same as with the mixin: both `debouncedFullName` and `fullNameDelay` are accessible on the object. For convenience, the delay can be set from the decorator, but the if `fullNameDelay` exist, it will have precedence, since it could be set at runtime as well. When you call the decorator without arguments (just `@decorator`), the default 1000ms delay will be used.
+
+### Usage
+
+Refer to `ember-computed-decorators`' [Babel Setup](https://github.com/rwjblue/ember-computed-decorators#babel-setup) chapter.
+
+### One More Thing&trade;
+
+It is, of course, could be used together with `ember-computed-decorators`!
+
+```js
+@debounced
+@computed('firstName', 'lastName')
+fullName(firstName, lastName) {
+  return `${firstName} ${lastName}`;
+}
+``` 
+
 
 ## License
 

--- a/addon/decorator.js
+++ b/addon/decorator.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+
+const { on, observer } = Ember;
+const { debounce } = Ember.run;
+const { capitalize } = Ember.String;
+
+function handleDescriptor(target, key, descriptor) {
+  const originalParams = descriptor.__originalParams || [];
+  const defaultWait = originalParams[0] || 1000;
+
+  const debouncedPropertyName = `debounced${capitalize(key)}`;
+  const updateFunctionName = `__setDebounced${capitalize(key)}`;
+
+  target[updateFunctionName] = function() {
+    if (!this.isDestroying || !this.isDestroyed) {
+      this.set(debouncedPropertyName, this.get(key));
+    }
+  };
+
+  target[`__init${capitalize(debouncedPropertyName)}`] = on('init', function() {
+    this[updateFunctionName]();
+  });
+
+  target[`__${debouncedPropertyName}DidChange`] = observer(key, function() {
+    const wait = this.getWithDefault(`${key}Delay`, defaultWait);
+
+    if (wait > 0) {
+      debounce(this, this[updateFunctionName], wait);
+    } else {
+      this[updateFunctionName]();
+    }
+  });
+
+  return descriptor;
+}
+
+function isDescriptor(item) {
+  return item && typeof item === 'object';
+}
+
+export default function debouncedDecorator(...params) {
+  // determine if user called as @debounced(500, 'name') or @debounced
+  if (isDescriptor(params[params.length - 1])) {
+    return handleDescriptor(...arguments);
+  } else {
+    return function(target, key, descriptor) {
+      descriptor.__originalParams = params;
+
+      return handleDescriptor(...arguments);
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "babel": "~5.1.5",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {

--- a/tests/dummy/app/templates/components/delayed-display.hbs
+++ b/tests/dummy/app/templates/components/delayed-display.hbs
@@ -1,1 +1,2 @@
-<h2>{{debouncedValue}}</h2>
+<p><code>value</code>: {{value}}</p>
+<p><code>debouncedValue</code>: {{debouncedValue}}</p>

--- a/tests/unit/debounced-properties-decorator-test.js
+++ b/tests/unit/debounced-properties-decorator-test.js
@@ -1,0 +1,83 @@
+/* global sinon */
+
+import Ember from 'ember';
+import { module } from 'qunit';
+import { test } from 'ember-qunit';
+import debounced from 'ember-debounced-properties/decorator';
+const { run } = Ember;
+let obj, clock;
+
+
+module('Decorator', {
+  setup: function() {
+    clock = sinon.useFakeTimers();
+  },
+
+  teardown: function() {
+    run(obj, 'destroy');
+    clock.restore();
+  }
+});
+
+test('default delay', function(assert) {
+  assert.expect(3);
+
+  obj = Ember.Object.extend({
+    /* jshint ignore:start */
+    @debounced
+    /* jshint ignore:end */
+    email: 'initial value'
+  }).create();
+
+
+  obj.set('email', 'hello@example.com');
+
+  assert.equal(obj.get('debouncedEmail'), 'initial value', "`debouncedEmail` isn't updated immediately.");
+
+  clock.tick(900);
+  assert.equal(obj.get('debouncedEmail'), 'initial value', "`debouncedEmail` isn't updated before 1000ms passed.");
+
+  clock.tick(100);
+  assert.equal(obj.get('debouncedEmail'), 'hello@example.com', "`debouncedEmail` is updated after 1000ms passed.");
+});
+
+test('custom delay as a decorator argument', function(assert) {
+  assert.expect(2);
+
+  obj = Ember.Object.extend({
+    /* jshint ignore:start */
+    @debounced(1500)
+    /* jshint ignore:end */
+    email: 'initial value'
+  }).create();
+
+
+  obj.set('email', 'hello@example.com');
+
+  clock.tick(1400);
+  assert.equal(obj.get('debouncedEmail'), 'initial value', "`debouncedEmail` isn't updated before 1500ms passed.");
+
+  clock.tick(100);
+  assert.equal(obj.get('debouncedEmail'), 'hello@example.com', "`debouncedEmail` is updated after 1500ms passed.");
+});
+
+test('custom delay using the `emailDelay` property works and takes precedence over the delay argument of `@debounced`', function(assert) {
+  assert.expect(2);
+
+  obj = Ember.Object.extend({
+    /* jshint ignore:start */
+    @debounced(200)
+    /* jshint ignore:end */
+    email: 'initial value',
+    emailDelay: 1500
+  }).create();
+
+
+  obj.set('email', 'hello@example.com');
+
+  clock.tick(1400);
+  assert.equal(obj.get('debouncedEmail'), 'initial value', "`debouncedEmail` isn't updated before 1500ms passed.");
+
+  clock.tick(100);
+  assert.equal(obj.get('debouncedEmail'), 'hello@example.com', "`debouncedEmail` is updated after 1500ms passed.");
+});


### PR DESCRIPTION
Inspired by [@rwjblue](https://github.com/rwjblue)'s awesome [ember-computed-decorators](https://github.com/rwjblue/ember-computed-decorators), it is now possible to use the ES7 decorator syntax to define debounced properties without using the mixin. All you have to do is to put a decorator (`@debounced`) over the property you want to have a debounced version. It can be a regular or a computed property, both will work just fine.

``` js
import Ember from 'ember';
import debounced from 'ember-debounced-properties/decorator';

port default Ember.Component.extend({
  firstName: 'John',
  lastName: 'Doe',

  @debounced(2000)
  fullName: Ember.computed('firstName', 'lastName', function() {
    return `${firstName} ${lastName}`;
  })
});
```

The result is the same as with the mixin: both `debouncedFullName` and `fullNameDelay` are accessible on the object. For convenience, the delay can be set from the decorator, but the if `fullNameDelay` exist, it will have precedence, since it could be set at runtime as well. When you call the decorator without arguments (just `@decorator`), the default 1000ms delay will be used.
### Usage

Refer to `ember-computed-decorators`' [Babel Setup](https://github.com/rwjblue/ember-computed-decorators#babel-setup) chapter.
### One More Thing&trade;

It is, of course, could be used together with `ember-computed-decorators`! :)

``` js
@debounced
@computed('firstName', 'lastName')
fullName(firstName, lastName) {
  return `${firstName} ${lastName}`;
}
```
